### PR TITLE
use URI instead of CID in contracts

### DIFF
--- a/packages/evm-contracts/contracts/IValist.sol
+++ b/packages/evm-contracts/contracts/IValist.sol
@@ -4,9 +4,9 @@ pragma solidity >=0.8.4;
 interface IValist {
 
   /// @dev emitted when a new team is created
-  event TeamCreated(string _teamName, string _metaCID, address _sender);
+  event TeamCreated(string _teamName, string _metaURI, address _sender);
   /// @dev emitted when an exsting team is updated
-  event TeamUpdated(string _teamName, string _metaCID, address _member);
+  event TeamUpdated(string _teamName, string _metaURI, address _member);
   /// @dev emitted when a new team member is added
   event TeamMemberAdded(string _teamName, address _member);
   /// @dev emitted when an existing team member is removed
@@ -16,7 +16,7 @@ interface IValist {
   event ProjectCreated(
     string _teamName, 
     string _projectName, 
-    string _metaCID, 
+    string _metaURI, 
     address _member
   );
 
@@ -24,7 +24,7 @@ interface IValist {
   event ProjectUpdated(
     string _teamName,
     string _projectName,
-    string _metaCID,
+    string _metaURI,
     address _member
   );
 
@@ -47,7 +47,7 @@ interface IValist {
     string _teamName, 
     string _projectName, 
     string _releaseName, 
-    string _metaCID, 
+    string _metaURI, 
     address _member
   );
 
@@ -70,11 +70,11 @@ interface IValist {
   /// Creates a new team with the given members.
   ///
   /// @param _teamName Unique name used to identify the team.
-  /// @param _metaCID Content ID of the team metadata.
+  /// @param _metaURI URI of the team metadata.
   /// @param _members List of members to add to the team.
   function createTeam(
     string memory _teamName, 
-    string memory _metaCID, 
+    string memory _metaURI, 
     address[] memory _members
   ) 
     external;
@@ -83,12 +83,12 @@ interface IValist {
   ///
   /// @param _teamName Name of the team to create the project under.
   /// @param _projectName Unique name used to identify the project.
-  /// @param _metaCID Content ID of the project metadata.
+  /// @param _metaURI URI of the project metadata.
   /// @param _members Optional list of members to add to the project.
   function createProject(
     string memory _teamName, 
     string memory _projectName,
-    string memory _metaCID,
+    string memory _metaURI,
     address[] memory _members
   )
     external;
@@ -98,12 +98,12 @@ interface IValist {
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
   /// @param _releaseName Unique name used to identify the release.
-  /// @param _metaCID Content ID of the project metadata.
+  /// @param _metaURI URI of the project metadata.
   function createRelease(
     string memory _teamName, 
     string memory _projectName,
     string memory _releaseName,
-    string memory _metaCID
+    string memory _metaURI
   )
     external;
 
@@ -169,43 +169,43 @@ interface IValist {
   )
     external;
 
-  /// Sets the team metadata content ID. Requires the sender to be a member of the team.
+  /// Sets the team metadata URI. Requires the sender to be a member of the team.
   ///
   /// @param _teamName Name of the team.
-  /// @param _metaCID Metadata content ID.
-  function setTeamMetaCID(
+  /// @param _metaURI Metadata URI.
+  function setTeamMetaURI(
     string memory _teamName,
-    string memory _metaCID
+    string memory _metaURI
   )
     external;
 
-  /// Sets the project metadata content ID. Requires the sender to be a member of the team.
+  /// Sets the project metadata URI. Requires the sender to be a member of the team.
   ///
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
-  /// @param _metaCID Metadata content ID.
-  function setProjectMetaCID(
+  /// @param _metaURI Metadata URI.
+  function setProjectMetaURI(
     string memory _teamName,
     string memory _projectName,
-    string memory _metaCID
+    string memory _metaURI
   )
     external;
 
-  /// Returns the team metadata CID.
+  /// Returns the team metadata URI.
   ///
   /// @param _teamName Name of the team.
-  function getTeamMetaCID(
+  function getTeamMetaURI(
     string memory _teamName
   )
     external
     view
     returns (string memory);
 
-  /// Returns the project metadata CID.
+  /// Returns the project metadata URI.
   ///
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
-  function getProjectMetaCID(
+  function getProjectMetaURI(
     string memory _teamName,
     string memory _projectName
   )
@@ -213,12 +213,12 @@ interface IValist {
     view
     returns (string memory);
 
-  /// Returns the release metadata CID.
+  /// Returns the release metadata URI.
   ///
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
   /// @param _releaseName Name of the release.
-  function getReleaseMetaCID(
+  function getReleaseMetaURI(
     string memory _teamName,
     string memory _projectName,
     string memory _releaseName

--- a/packages/evm-contracts/contracts/Valist.sol
+++ b/packages/evm-contracts/contracts/Valist.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /// @title Valist registry contract
 ///
-/// @custom:err-empty-meta metadata CID is required
+/// @custom:err-empty-meta metadata URI is required
 /// @custom:err-empty-members atleast one member is required
 /// @custom:err-empty-name name is required
 /// @custom:err-name-claimed name has already been claimed
@@ -45,7 +45,7 @@ contract Valist is IValist, ERC2771Context {
   mapping(uint256 => Project) private projectByID;
   /// @dev releaseID = keccak256(abi.encodePacked(projectID, keccak256(bytes(releaseName))))
   mapping(uint256 => Release) private releaseByID;
-  /// @dev mapping of team, project, and release IDs to metadata CIDs
+  /// @dev mapping of team, project, and release IDs to metadata URIs
   mapping(uint256 => string) private metaByID;
 
   /// @dev version of BaseRelayRecipient this contract implements
@@ -59,11 +59,11 @@ contract Valist is IValist, ERC2771Context {
   /// Creates a new team with the given members.
   ///
   /// @param _teamName Unique name used to identify the team.
-  /// @param _metaCID Content ID of the team metadata.
+  /// @param _metaURI URI of the team metadata.
   /// @param _members List of members to add to the team.
   function createTeam(
     string memory _teamName, 
-    string memory _metaCID, 
+    string memory _metaURI, 
     address[] memory _members
   ) 
     public
@@ -72,30 +72,30 @@ contract Valist is IValist, ERC2771Context {
     uint256 teamID = uint(keccak256(abi.encodePacked(block.chainid, keccak256(bytes(_teamName)))));
 
     require(bytes(metaByID[teamID]).length == 0, "err-name-claimed");
-    require(bytes(_metaCID).length > 0, "err-empty-meta");
+    require(bytes(_metaURI).length > 0, "err-empty-meta");
     require(bytes(_teamName).length > 0, "err-empty-name");
     require(_members.length > 0, "err-empty-members");
 
-    metaByID[teamID] = _metaCID;
+    metaByID[teamID] = _metaURI;
     teamNames.push(_teamName);
 
     for (uint i = 0; i < _members.length; i++) {
       teamByID[teamID].members.add(_members[i]);
     }
 
-    emit TeamCreated(_teamName, _metaCID, _msgSender());
+    emit TeamCreated(_teamName, _metaURI, _msgSender());
   }
   
   /// Creates a new project. Requires the sender to be a member of the team.
   ///
   /// @param _teamName Name of the team to create the project under.
   /// @param _projectName Unique name used to identify the project.
-  /// @param _metaCID Content ID of the project metadata.
+  /// @param _metaURI URI of the project metadata.
   /// @param _members Optional list of members to add to the project.
   function createProject(
     string memory _teamName, 
     string memory _projectName,
-    string memory _metaCID,
+    string memory _metaURI,
     address[] memory _members
   )
     public
@@ -106,17 +106,17 @@ contract Valist is IValist, ERC2771Context {
 
     require(teamByID[teamID].members.contains(_msgSender()), "err-team-member");
     require(bytes(metaByID[projectID]).length == 0, "err-name-claimed");
-    require(bytes(_metaCID).length > 0, "err-empty-meta");
+    require(bytes(_metaURI).length > 0, "err-empty-meta");
     require(bytes(_projectName).length > 0, "err-empty-name");
 
-    metaByID[projectID] = _metaCID;
+    metaByID[projectID] = _metaURI;
     teamByID[teamID].projectNames.push(_projectName);
 
     for (uint i = 0; i < _members.length; i++) {
       projectByID[projectID].members.add(_members[i]);
     }
 
-    emit ProjectCreated(_teamName, _projectName, _metaCID, _msgSender());
+    emit ProjectCreated(_teamName, _projectName, _metaURI, _msgSender());
   }
 
   /// Creates a new release. Requires the sender to be a member of the project.
@@ -124,12 +124,12 @@ contract Valist is IValist, ERC2771Context {
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
   /// @param _releaseName Unique name used to identify the release.
-  /// @param _metaCID Content ID of the project metadata.
+  /// @param _metaURI URI of the project metadata.
   function createRelease(
     string memory _teamName, 
     string memory _projectName,
     string memory _releaseName,
-    string memory _metaCID
+    string memory _metaURI
   )
     public
     override
@@ -140,12 +140,12 @@ contract Valist is IValist, ERC2771Context {
 
     require(projectByID[projectID].members.contains(_msgSender()), "err-proj-member");
     require(bytes(metaByID[releaseID]).length == 0, "err-name-claimed");
-    require(bytes(_metaCID).length > 0, "err-empty-meta");
+    require(bytes(_metaURI).length > 0, "err-empty-meta");
     require(bytes(_releaseName).length > 0, "err-empty-name");
 
-    metaByID[releaseID] = _metaCID;
+    metaByID[releaseID] = _metaURI;
     projectByID[projectID].releaseNames.push(_releaseName);
-    emit ReleaseCreated(_teamName, _projectName, _releaseName, _metaCID, _msgSender());
+    emit ReleaseCreated(_teamName, _projectName, _releaseName, _metaURI, _msgSender());
   }
 
   /// Approve the release by adding the sender's address to the approvers list.
@@ -274,13 +274,13 @@ contract Valist is IValist, ERC2771Context {
     emit ProjectMemberRemoved(_teamName, _projectName, _address);   
   }
 
-  /// Sets the team metadata content ID. Requires the sender to be a member of the team.
+  /// Sets the team metadata URI. Requires the sender to be a member of the team.
   ///
   /// @param _teamName Name of the team.
-  /// @param _metaCID Metadata content ID.
-  function setTeamMetaCID(
+  /// @param _metaURI Metadata URI.
+  function setTeamMetaURI(
     string memory _teamName,
-    string memory _metaCID
+    string memory _metaURI
   )
     public
     override
@@ -289,21 +289,21 @@ contract Valist is IValist, ERC2771Context {
 
     require(teamByID[teamID].members.contains(_msgSender()), "err-team-member");
     require(bytes(metaByID[teamID]).length > 0, "err-team-not-exist");
-    require(bytes(_metaCID).length > 0, "err-empty-meta");
+    require(bytes(_metaURI).length > 0, "err-empty-meta");
 
-    metaByID[teamID] = _metaCID;
-    emit TeamUpdated(_teamName, _metaCID, _msgSender());
+    metaByID[teamID] = _metaURI;
+    emit TeamUpdated(_teamName, _metaURI, _msgSender());
   }
 
-  /// Sets the project metadata content ID. Requires the sender to be a member of the team.
+  /// Sets the project metadata URI. Requires the sender to be a member of the team.
   ///
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
-  /// @param _metaCID Metadata content ID.
-  function setProjectMetaCID(
+  /// @param _metaURI Metadata URI.
+  function setProjectMetaURI(
     string memory _teamName,
     string memory _projectName,
-    string memory _metaCID
+    string memory _metaURI
   )
     public
     override
@@ -313,16 +313,16 @@ contract Valist is IValist, ERC2771Context {
 
     require(teamByID[teamID].members.contains(_msgSender()), "err-team-member");
     require(bytes(metaByID[projectID]).length > 0, "err-proj-not-exist");
-    require(bytes(_metaCID).length > 0, "err-empty-meta");
+    require(bytes(_metaURI).length > 0, "err-empty-meta");
 
-    metaByID[projectID] = _metaCID;
-    emit ProjectUpdated(_teamName, _projectName, _metaCID, _msgSender());
+    metaByID[projectID] = _metaURI;
+    emit ProjectUpdated(_teamName, _projectName, _metaURI, _msgSender());
   }
 
-  /// Returns the team metadata CID.
+  /// Returns the team metadata URI.
   ///
   /// @param _teamName Name of the team.
-  function getTeamMetaCID(
+  function getTeamMetaURI(
     string memory _teamName
   )
     public
@@ -335,11 +335,11 @@ contract Valist is IValist, ERC2771Context {
     return metaByID[teamID];
   }
 
-  /// Returns the project metadata CID.
+  /// Returns the project metadata URI.
   ///
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
-  function getProjectMetaCID(
+  function getProjectMetaURI(
     string memory _teamName,
     string memory _projectName
   )
@@ -354,12 +354,12 @@ contract Valist is IValist, ERC2771Context {
     return metaByID[projectID];
   }
 
-  /// Returns the release metadata CID.
+  /// Returns the release metadata URI.
   ///
   /// @param _teamName Name of the team.
   /// @param _projectName Name of the project.
   /// @param _releaseName Name of the release.
-  function getReleaseMetaCID(
+  function getReleaseMetaURI(
     string memory _teamName,
     string memory _projectName,
     string memory _releaseName

--- a/packages/evm-contracts/test/index.ts
+++ b/packages/evm-contracts/test/index.ts
@@ -608,7 +608,7 @@ describe("removeProjectMember", () => {
   });
 });
 
-describe("setTeamMetaCID", () => {
+describe("setTeamMetaURI", () => {
   it("Should emit TeamUpdated", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
@@ -616,7 +616,7 @@ describe("setTeamMetaCID", () => {
     const createTeamTx = await valist.createTeam("acme", "Qm", members);
     await createTeamTx.wait();
 
-    await expect(valist.setTeamMetaCID("acme", "baf"))
+    await expect(valist.setTeamMetaURI("acme", "baf"))
       .to.emit(valist, "TeamUpdated");
   });
 
@@ -627,7 +627,7 @@ describe("setTeamMetaCID", () => {
     const createTeamTx = await valist.createTeam("acme", "Qm", members.slice(1));
     await createTeamTx.wait();
 
-    await expect(valist.setTeamMetaCID("acme", "baf"))
+    await expect(valist.setTeamMetaURI("acme", "baf"))
       .to.be.revertedWith('err-team-member');
   });
 
@@ -638,7 +638,7 @@ describe("setTeamMetaCID", () => {
     const createTeamTx = await valist.createTeam("acme", "Qm", members);
     await createTeamTx.wait();
 
-    await expect(valist.setTeamMetaCID("", "baf"))
+    await expect(valist.setTeamMetaURI("", "baf"))
       .to.be.revertedWith('err-team-member');
   });
 
@@ -649,12 +649,12 @@ describe("setTeamMetaCID", () => {
     const createTeamTx = await valist.createTeam("acme", "Qm", members);
     await createTeamTx.wait();
 
-    await expect(valist.setTeamMetaCID("acme", ""))
+    await expect(valist.setTeamMetaURI("acme", ""))
       .to.be.revertedWith('err-empty-meta');
   });
 });
 
-describe("setProjectMetaCID", () => {
+describe("setProjectMetaURI", () => {
   it("Should emit ProjectUpdated", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
@@ -665,7 +665,7 @@ describe("setProjectMetaCID", () => {
     const createProjectTx = await valist.createProject("acme", "bin", "Qm", members);
     await createProjectTx.wait();
 
-    await expect(valist.setProjectMetaCID("acme", "bin", "baf"))
+    await expect(valist.setProjectMetaURI("acme", "bin", "baf"))
       .to.emit(valist, "ProjectUpdated");
   });
 
@@ -680,7 +680,7 @@ describe("setProjectMetaCID", () => {
     const createProjectTx = await valist.createProject("acme", "bin", "Qm", members);
     await createProjectTx.wait();
 
-    await expect(valist.connect(signers[1]).setProjectMetaCID("acme", "bin", "baf"))
+    await expect(valist.connect(signers[1]).setProjectMetaURI("acme", "bin", "baf"))
       .to.be.revertedWith('err-team-member');
   });
 
@@ -694,7 +694,7 @@ describe("setProjectMetaCID", () => {
     const createProjectTx = await valist.createProject("acme", "bin", "Qm", members);
     await createProjectTx.wait();
 
-    await expect(valist.setProjectMetaCID("", "bin", "baf"))
+    await expect(valist.setProjectMetaURI("", "bin", "baf"))
       .to.be.revertedWith('err-team-member');
   });
 
@@ -708,7 +708,7 @@ describe("setProjectMetaCID", () => {
     const createProjectTx = await valist.createProject("acme", "bin", "Qm", members);
     await createProjectTx.wait();
 
-    await expect(valist.setProjectMetaCID("acme", "", "baf"))
+    await expect(valist.setProjectMetaURI("acme", "", "baf"))
       .to.be.revertedWith('err-proj-not-exist');
   });
 
@@ -722,12 +722,12 @@ describe("setProjectMetaCID", () => {
     const createProjectTx = await valist.createProject("acme", "bin", "Qm", members);
     await createProjectTx.wait();
 
-    await expect(valist.setProjectMetaCID("acme", "bin", ""))
+    await expect(valist.setProjectMetaURI("acme", "bin", ""))
       .to.be.revertedWith('err-empty-meta');
   });
 });
 
-describe("getTeamMetaCID", () => {
+describe("getTeamMetaURI", () => {
   it("Should return team meta", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
@@ -735,20 +735,20 @@ describe("getTeamMetaCID", () => {
     const createTeamTx = await valist.createTeam("acme", "Qm", members);
     await createTeamTx.wait();
 
-    const metaCID = await valist.getTeamMetaCID("acme");
-    expect(metaCID).to.equal("Qm");
+    const metaURI = await valist.getTeamMetaURI("acme");
+    expect(metaURI).to.equal("Qm");
   });
 
   it("Should fail with non existant team", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
 
-    await expect(valist.getTeamMetaCID("acme"))
+    await expect(valist.getTeamMetaURI("acme"))
       .to.be.revertedWith('err-team-not-exist');
   });
 });
 
-describe("getProjectMetaCID", () => {
+describe("getProjectMetaURI", () => {
   it("Should return project meta", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
@@ -759,20 +759,20 @@ describe("getProjectMetaCID", () => {
     const createProjectTx = await valist.createProject("acme", "bin", "Qm2", []);
     await createProjectTx.wait();
 
-    const metaCID = await valist.getProjectMetaCID("acme", "bin");
-    expect(metaCID).to.equal("Qm2");
+    const metaURI = await valist.getProjectMetaURI("acme", "bin");
+    expect(metaURI).to.equal("Qm2");
   });
 
   it("Should fail with non existant project", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
 
-    await expect(valist.getProjectMetaCID("acme", "bin"))
+    await expect(valist.getProjectMetaURI("acme", "bin"))
       .to.be.revertedWith('err-proj-not-exist');
   });
 });
 
-describe("getReleaseMetaCID", () => {
+describe("getReleaseMetaURI", () => {
   it("Should return release meta", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
@@ -786,15 +786,15 @@ describe("getReleaseMetaCID", () => {
     const createReleaseTx = await valist.createRelease("acme", "bin", "0.0.1", "Qm3");
     await createReleaseTx.wait();
 
-    const metaCID = await valist.getReleaseMetaCID("acme", "bin", "0.0.1");
-    expect(metaCID).to.equal("Qm3");
+    const metaURI = await valist.getReleaseMetaURI("acme", "bin", "0.0.1");
+    expect(metaURI).to.equal("Qm3");
   });
 
   it("Should fail with non existant release", async function() {
     const valist = await deployValist();
     const members = await getAddresses();
 
-    await expect(valist.getReleaseMetaCID("acme", "bin", "0.0.1"))
+    await expect(valist.getReleaseMetaURI("acme", "bin", "0.0.1"))
       .to.be.revertedWith('err-release-not-exist');
   });
 });


### PR DESCRIPTION
Valist should be an extensible publishing protocol that supports any storage provider.

This PR replaces usages of CID with URI to reflect that.