### PR TITLE
add polling to graphql queries

### DIFF
--- a/packages/valist-web/pages/[teamName]/[projectName]/index.tsx
+++ b/packages/valist-web/pages/[teamName]/[projectName]/index.tsx
@@ -25,6 +25,7 @@ export default function ProjectPage():JSX.Element {
   const [version, setVersion] = useState<string>('');
   const { data, loading, error } = useQuery(PROJECT_PROFILE_QUERY, {
     variables: { project: projectID },
+    pollInterval: 5000,
   });
   const [view, setView] = useState<string>('Readme');
   const [licensePrice, setLicensePrice] = useState<BigNumberish | null>(null);

--- a/packages/valist-web/pages/[teamName]/index.tsx
+++ b/packages/valist-web/pages/[teamName]/index.tsx
@@ -20,13 +20,14 @@ export default function TeamProfilePage() {
   const teamName = `${router.query.teamName}`;
   const { data, loading, error } = useQuery(TEAM_PROFILE_QUERY, {
     variables: { team: teamName },
+    pollInterval: 5000,
   });
   const [view, setView] = useState<string>('Projects');
   const [meta, setMeta] = useState<TeamMeta>({
     image: '',
   });
   const [members, setMembers] = useState<TeamMember[]>([]);
-  const [projects, setaProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
   const tabs = [
     {
       text: 'Projects',
@@ -48,7 +49,7 @@ export default function TeamProfilePage() {
 
     if (data && data.teams && data.teams[0] && data.teams[0].metaURI) {
       fetchMeta(data.teams[0].metaURI);
-      setaProjects(data.teams[0].projects);
+      setProjects(data.teams[0].projects);
       setMembers(data.teams[0].members);
     }
   }, [data, loading, error, setMeta]);

--- a/packages/valist-web/pages/index.tsx
+++ b/packages/valist-web/pages/index.tsx
@@ -28,6 +28,7 @@ const Dashboard: NextPage = () => {
   const [userLicenses, setUserLicenses] = useState<License[]>([]);
   const { data, loading, error } = useQuery(USER_HOMEPAGE, {
     variables: { address: accountCtx.address.toLowerCase() },
+    pollInterval: 5000,
   });
   const isTeams = (userTeamNames.length !== 0);
   const isProjects = (currentProjects.length !== 0);


### PR DESCRIPTION
This PR adds polling to the main GraphQL queries.  This should help keep the pages up to date without the need to refresh.