### PR TITLE
Add donation fields and modal.

### DIFF
--- a/packages/valist-sdk/src/types.ts
+++ b/packages/valist-sdk/src/types.ts
@@ -1,13 +1,13 @@
 // Valist Types
 export class AccountMeta {
-  /** account image */
-  public image?: string;
-  /** account friendly name. */
-  public name?: string;
-  /** short description of the account. */
-  public description?: string;
-  /** link to the account website. */
-  public external_url?: string;
+	/** account image */
+	public image?: string;
+	/** account friendly name. */
+	public name?: string;
+	/** short description of the account. */
+	public description?: string;
+	/** link to the account website. */
+	public external_url?: string;
 }
 
 export class ProjectMeta {
@@ -29,6 +29,10 @@ export class ProjectMeta {
 	public tags?: string[];
 	/** videos and graphics of the project */
 	public gallery?: GalleryMeta[];
+	/** address where donations are sent*/
+	public donation_address?: string;
+	/** whether to prompt for donation */
+	public prompt_donation?: boolean;
 	/** launch project from external_url*/
 	public launch_external?: boolean;
 }

--- a/packages/valist-web/components/AddressInput/AddressInput.tsx
+++ b/packages/valist-web/components/AddressInput/AddressInput.tsx
@@ -7,12 +7,15 @@ const isENS = (address: string) => address.endsWith('.eth');
 const isAddress = (address: string) => ethers.utils.isAddress(address);
 
 export interface AddressProps {
+  value?: string;
+  label?: string;
   onSubmit: (address: string) => void;
+  required?: boolean;
   disabled?: boolean;
 }
 
 export function AddressInput(props: AddressProps) {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(props.value || '');
   const [error, setError] = useState('');
 
   const { data, isLoading } = useEnsAddress({ 
@@ -40,18 +43,19 @@ export function AddressInput(props: AddressProps) {
 
     if (isLoading || !isValid) return;
     props.onSubmit(data ?? value);
-    setValue('');  
+    setValue(value ? (data || value) : '');  
   };
 
   return (
     <AsyncInput
-      label="Add member"
+      label={props?.label || "Add member"}
       placeholder="Address or ENS"
       value={value} 
       error={error}
       disabled={props.disabled}
       loading={isLoading}
       valid={isValid}
+      required={props.required}
       onKeyPress={submit}
       onChange={(event) => setValue(event.currentTarget.value)}
     />

--- a/packages/valist-web/components/DonationInput/DonationInput.tsx
+++ b/packages/valist-web/components/DonationInput/DonationInput.tsx
@@ -1,0 +1,32 @@
+import { tokens } from "@/utils/tokens";
+import { Group, NumberInput, Select } from "@mantine/core";
+
+interface DonationInput {
+  currency: number;
+  onChange: any;
+  setCurrency: any;
+}
+
+export function DonationInput(props: DonationInput):JSX.Element {
+  return (
+    <Group spacing={'sm'}>
+      <Select
+        defaultValue={tokens.map((token, index) => index)[0].toString()}
+        onChange={props?.setCurrency} 
+        data={tokens.map((token, index) => 
+          ({
+            label: token.name,
+            value: index.toString(), 
+          }),
+        )}
+      />
+      <NumberInput
+        placeholder='2.0'
+        onChange={(value) => props.onChange(value || 0)}
+        min={0}
+        precision={4}
+        hideControls
+      />
+    </Group>
+  );
+}

--- a/packages/valist-web/components/DonationInput/index.ts
+++ b/packages/valist-web/components/DonationInput/index.ts
@@ -1,0 +1,1 @@
+export * from './DonationInput';

--- a/packages/valist-web/components/DonationModal/DonationModal.tsx
+++ b/packages/valist-web/components/DonationModal/DonationModal.tsx
@@ -1,8 +1,9 @@
+import { hideLoading, showErrorMessage, showLoading, updateLoading } from '@/forms/utils';
+import { tokens } from '@/utils/tokens';
 import {
   Stack,
   Title,
   Text,
-  NumberInput,
   Anchor,
 } from '@mantine/core';
 
@@ -10,13 +11,16 @@ import {
   Modal,
   Button,
 } from '@valist/ui';
-import { BigNumber, ethers } from 'ethers';
+import { ethers } from 'ethers';
 import { useState } from 'react';
-import { usePrepareSendTransaction, useSendTransaction } from 'wagmi';
+import { erc20ABI, useContract, useNetwork, usePrepareSendTransaction, useSendTransaction, useSigner } from 'wagmi';
+import { getBlockExplorer } from '../Activity';
+import { DonationInput } from '../DonationInput';
 
 export interface DonationModalProps {
   opened: boolean;
   projectName: string;
+  projectType: string;
   donationAddress: string;
   releaseURL:string;
   onClose: () => void;
@@ -24,17 +28,62 @@ export interface DonationModalProps {
 
 export function DonationModal(props: DonationModalProps) {
   const [amount, setAmount] = useState<number>(0);
+  const [currency, setCurrency] = useState<number>(0);
+  const [hasDonated, setHasDonated] = useState<boolean>(false);
 
-  console.log('props.donationAddress', props.donationAddress);
+  const { chain } = useNetwork();
+
+  const { data: signer } = useSigner();
+  const contract = useContract({
+    addressOrName: tokens[currency]?.address,
+    contractInterface: erc20ABI,
+    signerOrProvider: signer,
+  });
+
+  const sendERC20 = async () => {
+    try{
+      showLoading('Creating transaction');
+      const tx = await contract.transfer(props.donationAddress, ethers.utils.parseEther(amount.toString()));
+      const message = <Anchor target="_blank"  href={getBlockExplorer(chain?.id || 137, tx.hash)}>Waiting for transaction - View transaction</Anchor>;
+      
+      await tx.wait();
+      updateLoading(message);
+      setHasDonated(true);
+    } catch (error: any) {
+      showErrorMessage(error);
+      console.log(error.toString().includes('ERC20: transfer amount exceeds balance'));
+    } finally {
+      hideLoading();
+    }
+  };
+
   const { config } = usePrepareSendTransaction({
     request: { to: props.donationAddress, value: ethers.utils.parseEther(amount.toString()) },
   });
 
-  const { data, isLoading, isSuccess, sendTransaction } = useSendTransaction(config);
+  const { sendTransaction } = useSendTransaction({
+    ...config,
+    onError(error) {
+      showErrorMessage(error);
+    },
+    onSettled(data) {
+      (async () => {
+        const message = <Anchor target="_blank"  href={getBlockExplorer(chain?.id || 137, data?.hash || '')}>Waiting for transaction - View transaction</Anchor>;
+        showLoading(message);
+        setHasDonated(true);
 
-  const donate = () => {
-    console.log('data, isLoading, isSuccess, sendTransaction', data, isLoading, isSuccess, sendTransaction);
-    sendTransaction?.();
+        await data?.wait();
+        hideLoading();
+      })();
+    },
+  });
+
+  const donate = async () => {
+    if (currency === 0){
+      sendTransaction?.();
+    } else {
+      sendERC20();
+    }
   };
 
   return (
@@ -43,25 +92,34 @@ export function DonationModal(props: DonationModalProps) {
       onClose={props.onClose}
       image="/images/tokens.png"
     >
-      <Stack>
-        <Title>Download {props.projectName}</Title>
-        <Text>
-          This app is free but is accepting donations. <br/> Please consider supporting the creator by paying what you think is fair.
-        </Text>
-        <Anchor href={props?.releaseURL || ''} style={{ textDecoration: 'underline' }}>
-          No thanks, show me the download.
-        </Anchor>
-        <br/>
-        <NumberInput
-          label="Polygon Amount"
-          placeholder='2.0'
-          onChange={(value) => setAmount(value || 0)}
-          min={0}
-          precision={4}
-          hideControls
-        />
-        <Button onClick={donate}>Donate</Button>
-      </Stack>
+     {!hasDonated && 
+        <Stack>
+          <Title>{props.projectType === 'web' ?  'Launch' : 'Download'} {props.projectName}</Title>
+          <Text>
+            This app is free but is accepting donations. <br/> Please consider supporting the creator by paying what you think is fair.
+          </Text>
+          <Anchor target="_blank" href={props?.releaseURL || ''} style={{ textDecoration: 'underline' }}>
+            No thanks, {props.projectType === 'web' ?  'launch the application.' : 'show me the download.'}
+          </Anchor>
+          <br/>
+          <DonationInput
+            currency={currency} 
+            setCurrency={setCurrency} 
+            onChange={setAmount} 
+          />
+          <Button onClick={donate}>Donate</Button>
+        </Stack>
+      }
+      {hasDonated && 
+        <Stack>
+          <Text style={{ fontSize: 35 }}>
+            Thankyou for your contribution! ❤️
+          </Text>
+          <Anchor target="_blank" style={{ fontSize: 35, textDecoration: 'underline' }} href={props?.releaseURL || ''}>
+            {props.projectType === 'web' ?  'Launch application.' : 'Download.'}
+          </Anchor>
+        </Stack>
+      }
     </Modal>
   );
 }

--- a/packages/valist-web/components/DonationModal/DonationModal.tsx
+++ b/packages/valist-web/components/DonationModal/DonationModal.tsx
@@ -1,0 +1,67 @@
+import {
+  Stack,
+  Title,
+  Text,
+  NumberInput,
+  Anchor,
+} from '@mantine/core';
+
+import { 
+  Modal,
+  Button,
+} from '@valist/ui';
+import { BigNumber, ethers } from 'ethers';
+import { useState } from 'react';
+import { usePrepareSendTransaction, useSendTransaction } from 'wagmi';
+
+export interface DonationModalProps {
+  opened: boolean;
+  projectName: string;
+  donationAddress: string;
+  releaseURL:string;
+  onClose: () => void;
+}
+
+export function DonationModal(props: DonationModalProps) {
+  const [amount, setAmount] = useState<number>(0);
+
+  console.log('props.donationAddress', props.donationAddress);
+  const { config } = usePrepareSendTransaction({
+    request: { to: props.donationAddress, value: ethers.utils.parseEther(amount.toString()) },
+  });
+
+  const { data, isLoading, isSuccess, sendTransaction } = useSendTransaction(config);
+
+  const donate = () => {
+    console.log('data, isLoading, isSuccess, sendTransaction', data, isLoading, isSuccess, sendTransaction);
+    sendTransaction?.();
+  };
+
+  return (
+    <Modal
+      opened={props.opened}
+      onClose={props.onClose}
+      image="/images/tokens.png"
+    >
+      <Stack>
+        <Title>Download {props.projectName}</Title>
+        <Text>
+          This app is free but is accepting donations. <br/> Please consider supporting the creator by paying what you think is fair.
+        </Text>
+        <Anchor href={props?.releaseURL || ''} style={{ textDecoration: 'underline' }}>
+          No thanks, show me the download.
+        </Anchor>
+        <br/>
+        <NumberInput
+          label="Polygon Amount"
+          placeholder='2.0'
+          onChange={(value) => setAmount(value || 0)}
+          min={0}
+          precision={4}
+          hideControls
+        />
+        <Button onClick={donate}>Donate</Button>
+      </Stack>
+    </Modal>
+  );
+}

--- a/packages/valist-web/components/DonationModal/DonationModal.tsx
+++ b/packages/valist-web/components/DonationModal/DonationModal.tsx
@@ -116,7 +116,7 @@ export function DonationModal(props: DonationModalProps) {
             Thankyou for your contribution! ❤️
           </Text>
           <Anchor target="_blank" style={{ fontSize: 35, textDecoration: 'underline' }} href={props?.releaseURL || ''}>
-            {props.projectType === 'web' ?  'Launch application.' : 'Download.'}
+            {props.projectType === 'web' ?  'Launch application' : 'Download'}
           </Anchor>
         </Stack>
       }

--- a/packages/valist-web/components/DonationModal/index.ts
+++ b/packages/valist-web/components/DonationModal/index.ts
@@ -1,0 +1,1 @@
+export * from './DonationModal';

--- a/packages/valist-web/forms/update-project.tsx
+++ b/packages/valist-web/forms/update-project.tsx
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { string, z } from 'zod';
 import { ApolloCache } from '@apollo/client';
 import { ProjectMeta, Client } from '@valist/sdk';
 import { handleEvent } from './events';
@@ -14,8 +14,10 @@ export interface FormValues {
   shortDescription: string;
   youTubeLink: string;
   type: string;
+  donationAddress: string;
   tags: string[];
   launchExternal: boolean;
+  promptDonation: boolean;
 }
 
 export const schema = z.object({
@@ -30,6 +32,7 @@ export const schema = z.object({
     .max(100, { message: 'Description should be shorter than 100 characters' }),
   type: z.string(),
   tags: z.string().array(),
+  promptDonation: z.boolean(),
   launchExternal: z.boolean(),
 });
 
@@ -51,14 +54,19 @@ export async function updateProject(
       throw new Error('connect your wallet to continue');
     }
 
+    console.log('hello from updateProject');
+
     const meta: ProjectMeta = {
       name: values.displayName,
+      short_description: values.shortDescription,
       description: values.description,
       external_url: values.website,
       type: values.type,
       tags: values.tags,
       gallery: [],
       launch_external: values.launchExternal,
+      donation_address: values.donationAddress,
+      prompt_donation: values.promptDonation,
     };
 
     utils.showLoading('Uploading files');

--- a/packages/valist-web/forms/utils.tsx
+++ b/packages/valist-web/forms/utils.tsx
@@ -18,6 +18,21 @@ export const showError = (error: any) => showNotification({
   message: error.data?.message ?? error.message,
 });
 
+export const showErrorMessage = (error: any) => {
+  let message = error.toString();
+  if (error.toString().includes('ERC20: transfer amount exceeds balance')) {
+    message = 'ERC20: transfer amount exceeds balance';
+  }
+
+  showNotification({
+    id: ERROR_ID,
+    autoClose: false,
+    color: 'red',
+    title: 'Error',
+    message: message,
+  });
+};
+
 export const showLoading = (message: ReactNode) => showNotification({
   id: LOADING_ID,
   autoClose: false,

--- a/packages/valist-web/pages/-/account/[account]/project/[project]/pricing.tsx
+++ b/packages/valist-web/pages/-/account/[account]/project/[project]/pricing.tsx
@@ -26,9 +26,7 @@ import {
   Title,
   Stack,
   TextInput,
-  Textarea,
   NumberInput,
-  List,
   Tabs,
 } from '@mantine/core';
 

--- a/packages/valist-web/pages/-/account/[account]/project/[project]/settings.tsx
+++ b/packages/valist-web/pages/-/account/[account]/project/[project]/settings.tsx
@@ -30,6 +30,7 @@ import {
   Select,
   MultiSelect,
   Tabs,
+  Checkbox,
 } from '@mantine/core';
 
 import { 
@@ -79,6 +80,8 @@ const Project: NextPage = () => {
       type: '',
       tags: [],
       launchExternal: false,
+      donationAddress: '',
+      promptDonation: false,
     },
   });
 
@@ -91,10 +94,13 @@ const Project: NextPage = () => {
       form.setFieldValue('displayName', meta.name ?? '');
       form.setFieldValue('website', meta.external_url ?? '');
       form.setFieldValue('description', meta.description ?? '');
+      form.setFieldValue('shortDescription', meta.short_description ?? '');
       form.setFieldValue('youTubeLink', youTubeLink?.src ?? '');
       form.setFieldValue('tags', meta.tags ?? []);
       form.setFieldValue('type', meta.type ?? '');
       form.setFieldValue('launchExternal', meta.launch_external ?? false);
+      form.setFieldValue('promptDonation', meta.prompt_donation ?? false);
+      form.setFieldValue('donationAddress', meta.donation_address ?? false);
 
       setGallery(galleryLinks?.map((item: any) => item.src) ?? []);
       setMainCapsule(meta.main_capsule);
@@ -132,6 +138,7 @@ const Project: NextPage = () => {
   };
 
   const update = (values: FormValues) => {
+    console.log('update in settings', values);
     setLoading(true);
     updateProject(
       address,
@@ -166,6 +173,8 @@ const Project: NextPage = () => {
     { title: projectName, href: `/${accountName}/${projectName}` },
     { title: 'Settings', href: `/-/account/${accountName}/project/${projectName}/settings` },
   ];
+
+  console.log('form.values.donationAddress', form.values.donationAddress);
 
   return (
     <Layout>
@@ -210,6 +219,12 @@ const Project: NextPage = () => {
                 disabled={loading}
                 {...form.getInputProps('website')}
               />
+              <Checkbox
+                label="Launch from external website"
+                color="indigo"
+                size="sm"
+                {...form.getInputProps('launchExternal', { type: 'checkbox' })}
+              />
               <Select
                 label="Type"
                 data={defaultTypes}
@@ -229,11 +244,22 @@ const Project: NextPage = () => {
                 getCreateLabel={(query) => `+ Create ${query}`}
                 {...form.getInputProps('tags')}
               />
-              <Select
-                label="Launch External"
-                data={[{ label: "true", value: true }, { label: "false", value: false }]}
-                {...form.getInputProps('launchExternal')}
+
+              <Checkbox
+                label="Prompt for donation on download"
+                color="indigo"
+                size="sm"
+                {...form.getInputProps('promptDonation', { type: 'checkbox' })}
               />
+
+              {data?.prompt_donation || form.values.promptDonation &&
+                <AddressInput
+                  label="Donation Address"
+                  required
+                  value={form.values.donationAddress} 
+                  onSubmit={(address: string) => form.setFieldValue('donationAddress', address)} 
+                />
+              }
             </Stack>
             <Group mt="lg">
               <Button 

--- a/packages/valist-web/pages/[account]/[project]/index.tsx
+++ b/packages/valist-web/pages/[account]/[project]/index.tsx
@@ -37,6 +37,7 @@ import {
   Grid,
 } from '@mantine/core';
 import { checkIsElectron, getApps, install, launch } from '@/components/Electron';
+import { DonationModal } from '@/components/DonationModal';
 
 declare global {
   interface Window {
@@ -73,6 +74,7 @@ const ProjectPage: NextPage = () => {
   const [infoOpened, setInfoOpened] = useState(false);
   const showInfo = useMediaQuery('(max-width: 1400px)', false);
 
+  const [donationOpen, setDonationOpen] = useState(false);
   const [balance, setBalance] = useState(0);
   const [isElectron, setIsElectron] = useState<boolean>(false);
   const [isInstalled, setIsInstalled] = useState<boolean>(false);
@@ -177,8 +179,7 @@ const ProjectPage: NextPage = () => {
     rightActions.push({
       label: (projectMeta.type === 'native' || projectMeta.type === 'web') ? 'Launch' : 'Download',
       icon: Icon.Rocket,
-      href: launchUrl || '',
-      target: '_blank',
+      action: () => setDonationOpen(true),
       variant: 'primary',
     });
   }
@@ -201,8 +202,18 @@ const ProjectPage: NextPage = () => {
     );
   };
 
+  console.log('data?.donation_address', data?.donation_address);
+
   return (
     <Layout padding={0}>
+      <DonationModal 
+        opened={donationOpen}
+        projectName={`${accountName}/${projectName}`}
+        releaseURL={releaseMeta?.external_url}
+        donationAddress={data?.donation_address}
+        onClose={() => setDonationOpen(false)}
+      />
+
       <Group mt={40} pl={40} position="apart">
         <Breadcrumbs items={breadcrumbs} />
         { showInfo &&
@@ -302,12 +313,12 @@ const ProjectPage: NextPage = () => {
                         <Text>Version</Text>
                         <Text>{latestRelease?.name}</Text>
                       </Group>
-                      <Group position="apart">
+                      {projectMeta?.external_url && <Group position="apart">
                         <Text>Website</Text>
                         <Anchor href={projectMeta?.external_url ?? ''}>
                           {projectMeta?.external_url}
                         </Anchor>
-                      </Group>
+                      </Group>}
                     </List>
                   </Stack>
                 </Card>

--- a/packages/valist-web/pages/[account]/[project]/index.tsx
+++ b/packages/valist-web/pages/[account]/[project]/index.tsx
@@ -179,7 +179,13 @@ const ProjectPage: NextPage = () => {
     rightActions.push({
       label: (projectMeta.type === 'native' || projectMeta.type === 'web') ? 'Launch' : 'Download',
       icon: Icon.Rocket,
-      action: () => setDonationOpen(true),
+      action: () => {
+        if (projectMeta?.prompt_donation) {
+          setDonationOpen(true);
+        } else {
+          window.open(releaseMeta?.external_url);
+        }
+      },
       variant: 'primary',
     });
   }
@@ -202,16 +208,15 @@ const ProjectPage: NextPage = () => {
     );
   };
 
-  console.log('data?.donation_address', data?.donation_address);
-
   return (
     <Layout padding={0}>
       <DonationModal 
         opened={donationOpen}
         projectName={`${accountName}/${projectName}`}
+        projectType={projectMeta?.type}
         releaseURL={releaseMeta?.external_url}
-        donationAddress={data?.donation_address}
-        onClose={() => setDonationOpen(false)}
+        donationAddress={projectMeta?.donation_address}
+        onClose={() => setDonationOpen(false)}       
       />
 
       <Group mt={40} pl={40} position="apart">
@@ -224,7 +229,7 @@ const ProjectPage: NextPage = () => {
         }
       </Group>
       <div style={{ padding: 40 }}>
-        <ItemHeader 
+        <ItemHeader
           name={projectName}
           label={projectMeta?.name}
           image={projectMeta?.image}

--- a/packages/valist-web/pages/index.tsx
+++ b/packages/valist-web/pages/index.tsx
@@ -20,7 +20,6 @@ import {
   Stack,
   Grid,
   Text,
-  MediaQuery,
 } from '@mantine/core';
 
 import {
@@ -35,11 +34,9 @@ import {
   Welcome,
   CheckboxList,
 } from '@valist/ui';
-import { ValistContext } from '@/components/ValistProvider';
 
 const IndexPage: NextPage = () => {
   const router = useRouter();
-  const valist = useContext(ValistContext);
   const { account } = useContext(AccountContext);
   const { openConnectModal } = useConnectModal();
   const { isConnected } = useAccount();

--- a/packages/valist-web/pages/index.tsx
+++ b/packages/valist-web/pages/index.tsx
@@ -123,7 +123,7 @@ const IndexPage: NextPage = () => {
                           <ProjectCard
                             title={project.name} 
                             secondary={data?.name}
-                            description={data?.description} 
+                            description={data?.short_description} 
                             image={data?.image} 
                           />
                         </NextLink>

--- a/packages/valist-web/utils/tokens.ts
+++ b/packages/valist-web/utils/tokens.ts
@@ -67,7 +67,7 @@ export const tokens = [
 ];
 
 export function findToken(address: string) {
-  return tokens.find((token: any) => 
+  return tokens.find((token: any) =>
     token.address.toLowerCase() === address.toLowerCase(),
   );
 }


### PR DESCRIPTION
* Added `donation_address` & `prompt_donation` to Project Meta
* Added donation modal
* Hide the website on the profile if blank
* Regex on the profile website link.
* Show short_description instead of the full description on dashboard items.
* Fix broken short_description field on project settings
* Extended AddressInput to have optional `value` , `label`, and `required` props.