### PR TITLE
Fix 404 when completing GitHub workflow integration

### DIFF
--- a/packages/valist-web/pages/-/account/[account]/project/[project]/index.tsx
+++ b/packages/valist-web/pages/-/account/[account]/project/[project]/index.tsx
@@ -1,0 +1,15 @@
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+const ProjectIndex: NextPage = () => {
+    const router = useRouter();
+
+    useEffect(() => {
+        router.push(`/${router.query.account}/${router.query.project}`);
+    }, []);
+
+    return (<></>);
+};
+
+export default ProjectIndex;


### PR DESCRIPTION
When a user integrates GitHub and returns to Valist, the route is invalid: https://github.com/valist-io/valist-js/blob/4faed6fb691bf1fc5f9469217ff20109f4017772/packages/valist-web/pages/-/account/%5Baccount%5D/project/%5Bproject%5D/deployments.tsx#L87

To fix, rather than correcting the route, I introduced a helper page that automatically redirects any visits to this page to the project page w/ simpler URL.