### PR TITLE
Better URL formatting for nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17398,7 +17398,7 @@
     },
     "packages/valist-cli": {
       "name": "@valist/cli",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@oclif/core": "^1.8.0",
@@ -22735,7 +22735,7 @@
     },
     "packages/valist-sdk": {
       "name": "@valist/sdk",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "MPL-2.0",
       "dependencies": {
         "axios": "^1.0.0",

--- a/packages/valist-cli/README.md
+++ b/packages/valist-cli/README.md
@@ -14,7 +14,7 @@ $ npm install -g @valist/cli
 $ valist COMMAND
 running command...
 $ valist (--version)
-@valist/cli/2.7.1 darwin-arm64 node-v16.13.0
+@valist/cli/2.7.2 darwin-arm64 node-v16.13.0
 $ valist --help [COMMAND]
 USAGE
   $ valist COMMAND
@@ -53,7 +53,7 @@ EXAMPLES
   $ valist download ipfs/go-ipfs/v0.12.2 ~/Downloads/
 ```
 
-_See code: [dist/commands/download.ts](https://github.com/valist-io/valist-js/blob/v2.7.1/dist/commands/download.ts)_
+_See code: [dist/commands/download.ts](https://github.com/valist-io/valist-js/blob/v2.7.2/dist/commands/download.ts)_
 
 ## `valist help [COMMAND]`
 
@@ -90,7 +90,7 @@ EXAMPLES
   $ valist import
 ```
 
-_See code: [dist/commands/import.ts](https://github.com/valist-io/valist-js/blob/v2.7.1/dist/commands/import.ts)_
+_See code: [dist/commands/import.ts](https://github.com/valist-io/valist-js/blob/v2.7.2/dist/commands/import.ts)_
 
 ## `valist keygen`
 
@@ -107,7 +107,7 @@ EXAMPLES
   $ valist keygen
 ```
 
-_See code: [dist/commands/keygen.ts](https://github.com/valist-io/valist-js/blob/v2.7.1/dist/commands/keygen.ts)_
+_See code: [dist/commands/keygen.ts](https://github.com/valist-io/valist-js/blob/v2.7.2/dist/commands/keygen.ts)_
 
 ## `valist publish [PACKAGE] [PATH]`
 
@@ -135,5 +135,5 @@ EXAMPLES
   $ valist publish ipfs/go-ipfs/v0.12.3 dist/
 ```
 
-_See code: [dist/commands/publish.ts](https://github.com/valist-io/valist-js/blob/v2.7.1/dist/commands/publish.ts)_
+_See code: [dist/commands/publish.ts](https://github.com/valist-io/valist-js/blob/v2.7.2/dist/commands/publish.ts)_
 <!-- commandsstop -->

--- a/packages/valist-cli/package.json
+++ b/packages/valist-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valist/cli",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Valist CLI",
   "author": "Valist, Inc.",
   "bin": {

--- a/packages/valist-sdk/package.json
+++ b/packages/valist-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valist/sdk",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Web3-native software distribution.",
   "author": "Valist, Inc.",
   "contributors": [

--- a/packages/valist-sdk/src/client.ts
+++ b/packages/valist-sdk/src/client.ts
@@ -81,8 +81,10 @@ export default class Client {
 			Object.keys(filesObject).forEach((platform) => {
 				if (release.platforms && filesObject[platform] && filesObject[platform].length !== 0) {
 					const fileName = path.basename((filesObject[platform][0].name)); // @TODO make this work with folders
+					let url = new URL(nativeCID);
+					url.pathname = path.join(url.pathname, platform, fileName);
 					release.platforms[platform as SupportedPlatform] = {
-						external_url: path.join(nativeCID, platform, fileName),
+						external_url: url.toString(),
 						name: fileName,
 					};
 				}


### PR DESCRIPTION
Fixes issue in Node.js environments where multi-platform URLs for non-web platforms were generating with a missing `/` in the url scheme (i.e. "https:/" instead of "https://")

While did not affect most use cases due to smart browsers and tooling, it can break some tools and regex that don't fix or fit the scheme

Fixed metadata: https://bafkreihb27u6gw3wpg6nwn2tkq5kptcnhfb3jvf7aiju44e3y536clxs3y.ipfs.gateway.valist.io/
Incorrect metadata: https://bafkreigv2zxm55xsaqgxrwmpxgwrh3hdxjr44dltjji6zbpvnl5enli3tm.ipfs.gateway.valist.io/