### PR TITLE
FIX: use correct type name for games system_requirements

### DIFF
--- a/packages/valist-sdk/src/typesShared.ts
+++ b/packages/valist-sdk/src/typesShared.ts
@@ -55,7 +55,7 @@ export interface ProjectMetaInterface {
   /** repository used for deployments */
   repository?: string;
   /** hardware requirements */
-  systemRequirements?: SystemRequirements;
+  system_requirements?: SystemRequirements;
   /** supported compatibility layers (wine)  */
   wineSupport?: WineSupport;
 }


### PR DESCRIPTION
The actual payload of https://api.valist.io/v1/listings has `system_requirements` instead of `systemRequirements`

```json
"system_requirements": {
  "cpu": "2.9GHz dual-core Intel Core i5 or above",
  "gpu": "Intel Iris Graphics 550, NVIDIA GeForce GT 745M, AMD Radeon HD 7690M XT or above",
  "ram": "2GB",
  "disk": "4GB",
  "memory": ""
}
```